### PR TITLE
fix practice mode for reactive factory emeralds

### DIFF
--- a/data/Codes.xml
+++ b/data/Codes.xml
@@ -317,6 +317,18 @@
             <Value>6</Value>
             <ValueType>decimal</ValueType>
         </CodeLine>
+        <CodeLine>
+            <Type>writenop</Type>
+            <Address>00427A79</Address>
+            <Value>6</Value>
+            <ValueType>decimal</ValueType>
+        </CodeLine>
+        <CodeLine>
+            <Type>writenop</Type>
+            <Address>00427A8E</Address>
+            <Value>6</Value>
+            <ValueType>decimal</ValueType>
+        </CodeLine>
     </Code>
     <Code name="Easy Balloon Mode (All 17 Balloons Always Spawn)">
         <CodeLine>


### PR DESCRIPTION
yep, apparently there's 2 checks I missed on the Red/Gray emeralds that allow them to appear out of the explosions in stage.